### PR TITLE
Allow text 2.0

### DIFF
--- a/pandoc-lua-marshal.cabal
+++ b/pandoc-lua-marshal.cabal
@@ -54,7 +54,7 @@ common common-options
                      , hslua-marshalling     >= 2.1      && < 2.3
                      , pandoc-types          >= 1.22.1   && < 1.23
                      , safe                  >= 0.3      && < 0.4
-                     , text                  >= 1.1.1.0  && < 1.3
+                     , text                  >= 1.1.1.0  && < 1.3   || >= 2.0 && < 2.1
   
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
`for action in build test ; do cabal $action --enable-tests --constrain 'text == 2.0' || break ; done` passed:

```
Configuring library for pandoc-lua-marshal-0.1.5.1..
Preprocessing library for pandoc-lua-marshal-0.1.5.1..
Building library for pandoc-lua-marshal-0.1.5.1..
[ 1 of 28] Compiling Text.Pandoc.Lua.Marshal.Alignment
[ 2 of 28] Compiling Text.Pandoc.Lua.Marshal.CitationMode
[ 3 of 28] Compiling Text.Pandoc.Lua.Marshal.Filter
[ 4 of 28] Compiling Text.Pandoc.Lua.Marshal.Format
[ 5 of 28] Compiling Text.Pandoc.Lua.Marshal.List
[ 6 of 28] Compiling Text.Pandoc.Lua.Marshal.Attr
[ 7 of 28] Compiling Text.Pandoc.Lua.Marshal.ListAttributes
[ 8 of 28] Compiling Text.Pandoc.Lua.Marshal.MathType
[ 9 of 28] Compiling Text.Pandoc.Lua.Marshal.QuoteType
[10 of 28] Compiling Text.Pandoc.Lua.SpliceList
[11 of 28] Compiling Text.Pandoc.Lua.Walk
[12 of 28] Compiling Text.Pandoc.Lua.Topdown
[13 of 28] Compiling Text.Pandoc.Lua.Marshal.Inline[boot]
[14 of 28] Compiling Text.Pandoc.Lua.Marshal.Citation
[15 of 28] Compiling Text.Pandoc.Lua.Marshal.Block[boot]
[16 of 28] Compiling Text.Pandoc.Lua.Marshal.Shared
[17 of 28] Compiling Text.Pandoc.Lua.Marshal.Content
[18 of 28] Compiling Text.Pandoc.Lua.Marshal.Inline
[19 of 28] Compiling Text.Pandoc.Lua.Marshal.Cell
[20 of 28] Compiling Text.Pandoc.Lua.Marshal.Row
[21 of 28] Compiling Text.Pandoc.Lua.Marshal.TableHead
[22 of 28] Compiling Text.Pandoc.Lua.Marshal.TableFoot
[23 of 28] Compiling Text.Pandoc.Lua.Marshal.TableParts
[24 of 28] Compiling Text.Pandoc.Lua.Marshal.Block
[25 of 28] Compiling Text.Pandoc.Lua.Marshal.SimpleTable
[26 of 28] Compiling Text.Pandoc.Lua.Marshal.MetaValue
[27 of 28] Compiling Text.Pandoc.Lua.Marshal.Pandoc
[28 of 28] Compiling Text.Pandoc.Lua.Marshal.AST
Configuring test suite 'pandoc-lua-marshal-test' for pandoc-lua-marshal-0.1.5.1..
Preprocessing test suite 'pandoc-lua-marshal-test' for pandoc-lua-marshal-0.1.5.1..
Building test suite 'pandoc-lua-marshal-test' for pandoc-lua-marshal-0.1.5.1..
[1 of 1] Compiling Main
Linking /dev/shm/pandoc-lua-marshal/dist-newstyle/build/x86_64-linux/ghc-9.2.2/pandoc-lua-marshal-0.1.5.1/t/pandoc-lua-marshal-test/build/pandoc-lua-marshal-test/pandoc-lua-marshal-test ...
Build profile: -w ghc-9.2.2 -O1
In order, the following will be built (use -v for more details):
 - pandoc-lua-marshal-0.1.5.1 (test:pandoc-lua-marshal-test) (ephemeral targets)
Preprocessing test suite 'pandoc-lua-marshal-test' for pandoc-lua-marshal-0.1.5.1..
Building test suite 'pandoc-lua-marshal-test' for pandoc-lua-marshal-0.1.5.1..
Running 1 test suites...
Test suite pandoc-lua-marshal-test: RUNNING...
Test suite pandoc-lua-marshal-test: PASS
Test suite logged to:
/dev/shm/pandoc-lua-marshal/dist-newstyle/build/x86_64-linux/ghc-9.2.2/pandoc-lua-marshal-0.1.5.1/t/pandoc-lua-marshal-test/test/pandoc-lua-marshal-0.1.5.1-pandoc-lua-marshal-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```